### PR TITLE
Remove leading space from keywords.txt identifier token

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,7 +5,7 @@
 #######################################
 # Library (KEYWORD3)
 #######################################
-smeHumidity	     KEYWORD3
+smeHumidity	KEYWORD3
 
 #######################################
 # Datatypes (KEYWORD1)
@@ -14,13 +14,13 @@ smeHumidity	     KEYWORD3
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-begin	    KEYWORD2
-activate	    KEYWORD2
-deactivate	    KEYWORD2
-bduActivate	    KEYWORD2
-bduDeactivate	    KEYWORD2
-readHumidity	    KEYWORD2
-readTemperature	    KEYWORD2
+begin	KEYWORD2
+activate	KEYWORD2
+deactivate	KEYWORD2
+bduActivate	KEYWORD2
+bduDeactivate	KEYWORD2
+readHumidity	KEYWORD2
+readTemperature	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. Leading spaces on a keyword identifier causes it to not be recognized by the Arduino IDE. On Arduino IDE 1.6.5 and newer an unrecognized keyword identifier causes the default editor.function.style highlighting to be used (as with KEYWORD2, KEYWORD3, LITERAL2).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords